### PR TITLE
feat: gate utterance entry topic by legacy_namespace (AUDIO-IN-1 §5)

### DIFF
--- a/ovos_simple_listener/__main__.py
+++ b/ovos_simple_listener/__main__.py
@@ -41,8 +41,12 @@ class OVOSCallbacks(ListenerCallbacks):
     @classmethod
     def text_callback(cls, utterance: str, lang: str):
         LOG.info(f"STT: {utterance}")
-        cls.bus.emit(Message("recognizer_loop:utterance",
-                             {"utterances": [utterance], "lang": lang}))
+        payload = {"utterances": [utterance], "lang": lang}
+        # OVOS-AUDIO-IN-1 §5 utterance entry: legacy recognizer_loop:utterance or
+        # spec ovos.utterance.handle, per the deployment 'legacy_namespace' config.
+        topic = "recognizer_loop:utterance" \
+            if Configuration().get("legacy_namespace", True) else "ovos.utterance.handle"
+        cls.bus.emit(Message(topic, payload))
 
 
 def main():

--- a/test/unittests/test_spec_bus_messages.py
+++ b/test/unittests/test_spec_bus_messages.py
@@ -1,0 +1,49 @@
+"""Namespace bus-message tests.
+
+The utterance entry topic is emitted in exactly one namespace, chosen by the
+``legacy_namespace`` config (default True): the legacy
+``recognizer_loop:utterance`` or the OVOS-AUDIO-IN-1 §5 ``ovos.utterance.handle``.
+Both modes are covered here.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from ovos_config.config import Configuration
+
+from ovos_simple_listener.__main__ import OVOSCallbacks
+
+
+class TestUtteranceEntryNamespace(unittest.TestCase):
+
+    def setUp(self):
+        self.bus = MagicMock()
+        OVOSCallbacks.bus = self.bus
+
+    def tearDown(self):
+        Configuration()["legacy_namespace"] = True
+
+    def _topics(self):
+        return [c.args[0].msg_type for c in self.bus.emit.call_args_list]
+
+    def _payloads(self):
+        return {c.args[0].msg_type: c.args[0].data for c in self.bus.emit.call_args_list}
+
+    def test_legacy_namespace_emits_only_legacy_topic(self):
+        Configuration()["legacy_namespace"] = True
+        OVOSCallbacks.text_callback("hello world", "en-US")
+        self.assertIn("recognizer_loop:utterance", self._topics())
+        self.assertNotIn("ovos.utterance.handle", self._topics())
+        self.assertEqual(self._payloads()["recognizer_loop:utterance"],
+                         {"utterances": ["hello world"], "lang": "en-US"})
+
+    def test_spec_namespace_emits_only_spec_topic(self):
+        Configuration()["legacy_namespace"] = False
+        OVOSCallbacks.text_callback("hello world", "en-US")
+        self.assertIn("ovos.utterance.handle", self._topics())
+        self.assertNotIn("recognizer_loop:utterance", self._topics())
+        self.assertEqual(self._payloads()["ovos.utterance.handle"],
+                         {"utterances": ["hello world"], "lang": "en-US"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Emit either the legacy `recognizer_loop:utterance` or the spec `ovos.utterance.handle` (OVOS-AUDIO-IN-1 §5), chosen by the deployment `legacy_namespace` config (default `True`) — never both. Part of the org-wide `mycroft.* → ovos.*` bus-namespace transition (companion to ovos-core / ovos-workshop). Dual-namespace tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)